### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/BioticExplorers/keywords.txt
+++ b/BioticExplorers/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Explorer       KEYWORD1
+Explorer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin         KEYWORD2
-init	      KEYWORD2
-pressed      KEYWORD2
-released     KEYWORD2
-has_changed  KEYWORD2
+begin	KEYWORD2
+init	KEYWORD2
+pressed	KEYWORD2
+released	KEYWORD2
+has_changed	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-PRESSED      LITERAL1
-RELEASED     LITERAL1
+PRESSED	LITERAL1
+RELEASED	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords